### PR TITLE
(PE-31359) add `UseCNVerification` flag for puppetdb app

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
       GOPATH: ${{ github.workspace }}
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/app/puppetdb-cli/api/swaggerclient.go
+++ b/app/puppetdb-cli/api/swaggerclient.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -16,6 +18,7 @@ import (
 //SwaggerClientCfg represents a puppetdb-cli swagger client cfg
 type SwaggerClientCfg struct {
 	Cacert, Cert, Key, URL, Token string
+	UseCNVerification             bool
 }
 
 //SwaggerClient represents a puppetdb-cli swagger client
@@ -92,12 +95,38 @@ func (sc *SwaggerClient) getHTTPClient() (*http.Client, error) {
 		return nil, err
 	}
 
+	if sc.UseCNVerification { // check server name against CN only
+		enableCNVerification(cfg)
+	}
+
 	transport := &http.Transport{
 		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: cfg,
 	}
 
 	return &http.Client{Transport: transport}, nil
+}
+
+// This code is based https://github.com/golang/go/issues/40748#issuecomment-673612108
+// and should be used only as a workaround until all puppetdb servers certificates
+// are properly generated (and have the SAN fields added)
+func enableCNVerification(cfg *tls.Config) {
+	cfg.InsecureSkipVerify = true
+	cfg.VerifyConnection = func(cs tls.ConnectionState) error {
+		commonName := cs.PeerCertificates[0].Subject.CommonName
+		if commonName != cs.ServerName {
+			return fmt.Errorf("invalid certificate name %q, expected %q", commonName, cs.ServerName)
+		}
+		opts := x509.VerifyOptions{
+			Roots:         cfg.RootCAs,
+			Intermediates: x509.NewCertPool(),
+		}
+		for _, cert := range cs.PeerCertificates[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+		_, err := cs.PeerCertificates[0].Verify(opts)
+		return err
+	}
 }
 
 func newOpenAPITransport(url url.URL, httpclient *http.Client) *openapihttptransport.Runtime {

--- a/app/puppetdb-cli/api/swaggerclient_test.go
+++ b/app/puppetdb-cli/api/swaggerclient_test.go
@@ -12,12 +12,9 @@ func TestGetClientFailsIfNoUrl(t *testing.T) {
 	assert := assert.New(t)
 	errorMessage := "Invalid scheme for "
 
-	cacert := ""
-	cert := ""
-	key := ""
-	url := ""
-	token := ""
-	client := NewClient(cacert, cert, key, url, token)
+	swaggerCfg := SwaggerClientCfg{}
+	client := NewClientWithConfig(swaggerCfg)
+
 	_, receivedError := client.GetClient()
 	assert.EqualError(receivedError, errorMessage)
 }
@@ -25,12 +22,10 @@ func TestGetClientFailsIfNoUrl(t *testing.T) {
 func TestGetClientSuccessIfHTTP(t *testing.T) {
 	assert := assert.New(t)
 
-	cacert := ""
-	cert := ""
-	key := ""
-	url := "http://random3751.com"
-	token := ""
-	client := NewClient(cacert, cert, key, url, token)
+	swaggerCfg := SwaggerClientCfg{
+		URL: "http://random3751.com",
+	}
+	client := NewClientWithConfig(swaggerCfg)
 
 	_, receivedError := client.GetClient()
 	assert.NoError(receivedError)
@@ -40,12 +35,10 @@ func TestGetClientFailsIfHTTPSNoToken(t *testing.T) {
 	assert := assert.New(t)
 	errorMessage := "ssl requires a token, please use `puppet access login` to retrieve a token (alternatively use 'cert' and 'key' for whitelist validation)"
 
-	cacert := ""
-	cert := ""
-	key := ""
-	url := "https://random3751.com"
-	token := ""
-	client := NewClient(cacert, cert, key, url, token)
+	swaggerCfg := SwaggerClientCfg{
+		URL: "https://random3751.com",
+	}
+	client := NewClientWithConfig(swaggerCfg)
 
 	_, receivedError := client.GetClient()
 	assert.EqualError(receivedError, errorMessage)
@@ -54,12 +47,11 @@ func TestGetClientFailsIfHTTPSNoToken(t *testing.T) {
 func TestGetClientSuccessIfHTTPSWithToken(t *testing.T) {
 	assert := assert.New(t)
 
-	cacert := ""
-	cert := ""
-	key := ""
-	url := "https://random3751.com"
-	token := filepath.Join(testdata.FixturePath(), "token")
-	client := NewClient(cacert, cert, key, url, token)
+	swaggerCfg := SwaggerClientCfg{
+		URL:   "https://random3751.com",
+		Token: filepath.Join(testdata.FixturePath(), "token"),
+	}
+	client := NewClientWithConfig(swaggerCfg)
 
 	_, receivedError := client.GetClient()
 	assert.NoError(receivedError)
@@ -68,12 +60,13 @@ func TestGetClientSuccessIfHTTPSWithToken(t *testing.T) {
 func TestGetClientSuccessIfHTTPSWithCertAndKey(t *testing.T) {
 	assert := assert.New(t)
 
-	cacert := ""
-	cert := filepath.Join(testdata.FixturePath(), "cert.crt")
-	key := filepath.Join(testdata.FixturePath(), "private_key.key")
-	url := "https://random3751.com"
-	token := ""
-	client := NewClient(cacert, cert, key, url, token)
+	swaggerCfg := SwaggerClientCfg{
+		Cert: filepath.Join(testdata.FixturePath(), "cert.crt"),
+		Key:  filepath.Join(testdata.FixturePath(), "private_key.key"),
+		URL:  "http://random3751.com",
+	}
+
+	client := NewClientWithConfig(swaggerCfg)
 
 	_, receivedError := client.GetClient()
 	assert.NoError(receivedError)
@@ -82,12 +75,11 @@ func TestGetClientSuccessIfHTTPSWithCertAndKey(t *testing.T) {
 func TestGetClientFailsIfCannotParse(t *testing.T) {
 	assert := assert.New(t)
 
-	cacert := ""
-	cert := ""
-	key := ""
-	url := "§¶£¡:random.com"
-	token := ""
-	client := NewClient(cacert, cert, key, url, token)
+	swaggerCfg := SwaggerClientCfg{
+		URL: "§¶£¡:random.com",
+	}
+	client := NewClientWithConfig(swaggerCfg)
+
 	_, receivedError := client.GetClient()
 	assert.Error(receivedError)
 }

--- a/app/puppetdb-cli/puppet-db.go
+++ b/app/puppetdb-cli/puppet-db.go
@@ -7,27 +7,36 @@ import (
 
 var appFS = afero.NewOsFs()
 
+// PuppetDbCfg is a pupperDB client configuration
+type PuppetDbCfg struct {
+	URL    string
+	Token  string
+	Cacert string
+	Cert   string
+	Key    string
+}
+
 // PuppetDb interface
 type PuppetDb struct {
-	URL     string
 	Token   string
-	Cacert  string
-	Cert    string
-	Key     string
 	Version string
-	Client  api.Client
+
+	Client api.Client
 }
 
 // NewWithConfig creates a puppet code application with configuration
-func NewWithConfig(url, cacert, cert, key, token string) *PuppetDb {
-	return &PuppetDb{
-		URL:    url,
-		Cacert: cacert,
-		Cert:   cert,
-		Key:    key,
-		Token:  token,
+func NewWithConfig(cfg PuppetDbCfg) *PuppetDb {
+	apiCfg := api.SwaggerClientCfg{
+		Cacert: cfg.Cacert,
+		Cert:   cfg.Cert,
+		Key:    cfg.Key,
+		URL:    cfg.URL,
+		Token:  cfg.Token,
+	}
 
-		Client: api.NewClient(cacert, cert, key, url, token),
+	return &PuppetDb{
+		Token:  cfg.Token,
+		Client: api.NewClientWithConfig(apiCfg),
 	}
 }
 
@@ -42,6 +51,6 @@ func NewPuppetDbApp(version string) *PuppetDb {
 func New() *PuppetDb {
 	return &PuppetDb{
 		Token:  "",
-		Client: api.NewClient("", "", "", "", ""),
+		Client: api.NewClientWithConfig(api.SwaggerClientCfg{}),
 	}
 }

--- a/app/puppetdb-cli/puppet-db.go
+++ b/app/puppetdb-cli/puppet-db.go
@@ -14,6 +14,8 @@ type PuppetDbCfg struct {
 	Cacert string
 	Cert   string
 	Key    string
+
+	UseCNVerification bool
 }
 
 // PuppetDb interface
@@ -27,11 +29,12 @@ type PuppetDb struct {
 // NewWithConfig creates a puppet code application with configuration
 func NewWithConfig(cfg PuppetDbCfg) *PuppetDb {
 	apiCfg := api.SwaggerClientCfg{
-		Cacert: cfg.Cacert,
-		Cert:   cfg.Cert,
-		Key:    cfg.Key,
-		URL:    cfg.URL,
-		Token:  cfg.Token,
+		Cacert:            cfg.Cacert,
+		Cert:              cfg.Cert,
+		Key:               cfg.Key,
+		URL:               cfg.URL,
+		Token:             cfg.Token,
+		UseCNVerification: cfg.UseCNVerification,
 	}
 
 	return &PuppetDb{


### PR DESCRIPTION
When `UseCNVerification` flag is set, it will check servername against CN
instead of SAN, allowing connections to servers without servername
listed in SAN as long as it matches CN

