### PR TITLE
(CT-164) Fix useless error when puppet-access unconfigured 

### DIFF
--- a/app/puppet-access/api/api.yaml
+++ b/app/puppet-access/api/api.yaml
@@ -22,10 +22,18 @@ paths:
             properties:
               token:
                 type: string
+        400:
+          description: Bad request
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Authorization error
+          schema:
+            $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
-            $ref: '#/definitions/Error'
+            type: string
 
 definitions:
   Error:

--- a/app/puppet-access/api/client/operations/login_responses.go
+++ b/app/puppet-access/api/client/operations/login_responses.go
@@ -31,6 +31,18 @@ func (o *LoginReader) ReadResponse(response runtime.ClientResponse, consumer run
 			return nil, err
 		}
 		return result, nil
+	case 400:
+		result := NewLoginBadRequest()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
+	case 401:
+		result := NewLoginUnauthorized()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		result := NewLoginDefault(response.Code())
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -75,6 +87,70 @@ func (o *LoginOK) readResponse(response runtime.ClientResponse, consumer runtime
 	return nil
 }
 
+// NewLoginBadRequest creates a LoginBadRequest with default headers values
+func NewLoginBadRequest() *LoginBadRequest {
+	return &LoginBadRequest{}
+}
+
+/* LoginBadRequest describes a response with status code 400, with default header values.
+
+Bad request
+*/
+type LoginBadRequest struct {
+	Payload *models.Error
+}
+
+func (o *LoginBadRequest) Error() string {
+	return fmt.Sprintf("[POST /auth/token][%d] loginBadRequest  %+v", 400, o.Payload)
+}
+func (o *LoginBadRequest) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *LoginBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewLoginUnauthorized creates a LoginUnauthorized with default headers values
+func NewLoginUnauthorized() *LoginUnauthorized {
+	return &LoginUnauthorized{}
+}
+
+/* LoginUnauthorized describes a response with status code 401, with default header values.
+
+Authorization error
+*/
+type LoginUnauthorized struct {
+	Payload *models.Error
+}
+
+func (o *LoginUnauthorized) Error() string {
+	return fmt.Sprintf("[POST /auth/token][%d] loginUnauthorized  %+v", 401, o.Payload)
+}
+func (o *LoginUnauthorized) GetPayload() *models.Error {
+	return o.Payload
+}
+
+func (o *LoginUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
 // NewLoginDefault creates a LoginDefault with default headers values
 func NewLoginDefault(code int) *LoginDefault {
 	return &LoginDefault{
@@ -89,7 +165,7 @@ Unexpected error
 type LoginDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the login default response
@@ -100,16 +176,14 @@ func (o *LoginDefault) Code() int {
 func (o *LoginDefault) Error() string {
 	return fmt.Sprintf("[POST /auth/token][%d] login default  %+v", o._statusCode, o.Payload)
 }
-func (o *LoginDefault) GetPayload() *models.Error {
+func (o *LoginDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *LoginDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/app/puppet-access/api/client/operations/operations_client.go
+++ b/app/puppet-access/api/client/operations/operations_client.go
@@ -23,12 +23,9 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
-type ClientOption func(*runtime.ClientOperation)
-
 // ClientService is the interface for Client methods
 type ClientService interface {
-	Login(params *LoginParams, opts ...ClientOption) (*LoginOK, error)
+	Login(params *LoginParams) (*LoginOK, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -36,12 +33,13 @@ type ClientService interface {
 /*
   Login login API
 */
-func (a *Client) Login(params *LoginParams, opts ...ClientOption) (*LoginOK, error) {
+func (a *Client) Login(params *LoginParams) (*LoginOK, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewLoginParams()
 	}
-	op := &runtime.ClientOperation{
+
+	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "login",
 		Method:             "POST",
 		PathPattern:        "/auth/token",
@@ -52,12 +50,7 @@ func (a *Client) Login(params *LoginParams, opts ...ClientOption) (*LoginOK, err
 		Reader:             &LoginReader{formats: a.formats},
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	}
-	for _, opt := range opts {
-		opt(op)
-	}
-
-	result, err := a.transport.Submit(op)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/app/puppet-access/api/client/operations/testing/operations_client_mock.go
+++ b/app/puppet-access/api/client/operations/testing/operations_client_mock.go
@@ -36,23 +36,18 @@ func (m *MockClientService) EXPECT() *MockClientServiceMockRecorder {
 }
 
 // Login mocks base method
-func (m *MockClientService) Login(params *operations.LoginParams, opts ...operations.ClientOption) (*operations.LoginOK, error) {
+func (m *MockClientService) Login(params *operations.LoginParams) (*operations.LoginOK, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{params}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Login", varargs...)
+	ret := m.ctrl.Call(m, "Login", params)
 	ret0, _ := ret[0].(*operations.LoginOK)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Login indicates an expected call of Login
-func (mr *MockClientServiceMockRecorder) Login(params interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockClientServiceMockRecorder) Login(params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{params}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockClientService)(nil).Login), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Login", reflect.TypeOf((*MockClientService)(nil).Login), params)
 }
 
 // SetTransport mocks base method

--- a/app/puppet-access/api/swaggerclient.go
+++ b/app/puppet-access/api/swaggerclient.go
@@ -32,9 +32,18 @@ func NewClient(login, password, lifetime, url, label, cacert string) Client {
 
 //GetClient configures and creates a swagger generated client
 func (sc *SwaggerClient) GetClient() (*client.PuppetAccess, error) {
+	if sc.url == "" {
+		err := fmt.Errorf("Please provide the service URL. For example, `puppet-access login [username] --service-url https://<HOSTNAME OF PUPPET ENTERPRISE CONSOLE>:4433/rbac-ap`")
+		return nil, err
+	}
 
 	url, err := url.Parse(sc.url)
 	if err != nil {
+		return nil, err
+	}
+
+	if url.Scheme != "http" && url.Scheme != "https" {
+		err = fmt.Errorf("Unsupported protocol scheme: %v", url.Scheme)
 		return nil, err
 	}
 

--- a/app/puppet-access/login_test.go
+++ b/app/puppet-access/login_test.go
@@ -35,11 +35,11 @@ func TestRunLoginFailsIfNoClient(t *testing.T) {
 func TestRunLoginFailure(t *testing.T) {
 	assert := assert.New(t)
 
-	errorMessage := "Received unexpected error:"
 	login := "username"
 	password := "pass"
 	lifetime := "10m"
 	label := "test_token"
+	errorMessage := "Salam"
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -71,7 +71,7 @@ func TestRunLoginFailure(t *testing.T) {
 
 	_, receivedError := puppetAccess.Login()
 
-	assert.EqualError(receivedError, errorMessage)
+	assert.EqualError(receivedError, "Unknown error: "+errorMessage)
 }
 
 func TestRunLoginSuccess(t *testing.T) {


### PR DESCRIPTION
Puppet-access provides a useless error when unconfigured